### PR TITLE
Filter issues with their assignees

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,4 +36,9 @@ steps:
       # then you would set this to "true". Otherwise, all issues are evaluated.
       # Options: "true", "false" (default).
       # onlyMilestone: false
+
+      # If you want process issue with specific assignees, specify the user names in array.
+      # Otherwise, all issues are evaluated.
+      # Example: [] (default), ["user1", "user2", "user3"]
+      # assignees: []
 ```

--- a/README.md
+++ b/README.md
@@ -41,4 +41,9 @@ steps:
       # Otherwise, all issues are evaluated.
       # Example: [] (default), ["user1", "user2", "user3"]
       # assignees: []
+
+      # If you want exclude issue with specific assignees, specify the user names in array.
+      # Otherwise, all issues are evaluated.
+      # Example: [] (default), ["user1", "user2", "user3"]
+      # assigneesExcluded: []
 ```

--- a/action.yaml
+++ b/action.yaml
@@ -22,6 +22,10 @@ inputs:
     description: Only check issues that are part of a milestone
     required: false
     default: "false"
+  assignees:
+    description: Only check issues that have assignees at least one of this parameter
+    required: false
+    default: "[]"
 runs:
   using: docker
   image: docker://ghcr.io/trstringer/require-label-prefix:1.0.1

--- a/action.yaml
+++ b/action.yaml
@@ -26,6 +26,10 @@ inputs:
     description: Only check issues that have assignees at least one of this parameter
     required: false
     default: "[]"
+  assigneesExcluded:
+    description: Only check issues that do not have assignees any of this parameter
+    required: false
+    default: "[]"
 runs:
   using: docker
   image: docker://ghcr.io/trstringer/require-label-prefix:1.0.1

--- a/config.go
+++ b/config.go
@@ -7,15 +7,15 @@ import (
 )
 
 type configuration struct {
-	repoOwner      string
-	repoName       string
-	token          string
-	labelPrefix    string
-	labelSeparator string
-	addLabel       bool
-	defaultLabel   string
-	onlyMilestone  bool
-	assignees      []string
+	repoOwner         string
+	repoName          string
+	token             string
+	labelPrefix       string
+	labelSeparator    string
+	addLabel          bool
+	defaultLabel      string
+	onlyMilestone     bool
+	assignees         []string
 	assigneesExcluded []string
 }
 
@@ -51,15 +51,15 @@ func newConfiguration() (*configuration, error) {
 	assigneesExcluded := strings.Split(os.Getenv(envVarAssigneesExcluded), ",")
 
 	return &configuration{
-		repoOwner:      repoOwner,
-		repoName:       repoName,
-		token:          os.Getenv(envVarToken),
-		labelPrefix:    labelPrefix,
-		labelSeparator: labelSeparator,
-		addLabel:       addLabel,
-		defaultLabel:   defaultLabel,
-		onlyMilestone:  os.Getenv(envVarOnlyMilestone) == "true",
-		assignees:      assignees,
+		repoOwner:         repoOwner,
+		repoName:          repoName,
+		token:             os.Getenv(envVarToken),
+		labelPrefix:       labelPrefix,
+		labelSeparator:    labelSeparator,
+		addLabel:          addLabel,
+		defaultLabel:      defaultLabel,
+		onlyMilestone:     os.Getenv(envVarOnlyMilestone) == "true",
+		assignees:         assignees,
 		assigneesExcluded: assigneesExcluded,
 	}, nil
 }

--- a/config.go
+++ b/config.go
@@ -15,6 +15,7 @@ type configuration struct {
 	addLabel       bool
 	defaultLabel   string
 	onlyMilestone  bool
+	assignees      []string
 }
 
 func newConfiguration() (*configuration, error) {
@@ -45,6 +46,7 @@ func newConfiguration() (*configuration, error) {
 	}
 	repoOwner := repoParts[0]
 	repoName := repoParts[1]
+	assignees := strings.Split(os.Getenv(envVarAssignees), ",")
 
 	return &configuration{
 		repoOwner:      repoOwner,
@@ -55,5 +57,6 @@ func newConfiguration() (*configuration, error) {
 		addLabel:       addLabel,
 		defaultLabel:   defaultLabel,
 		onlyMilestone:  os.Getenv(envVarOnlyMilestone) == "true",
+		assignees:      assignees,
 	}, nil
 }

--- a/config.go
+++ b/config.go
@@ -16,6 +16,7 @@ type configuration struct {
 	defaultLabel   string
 	onlyMilestone  bool
 	assignees      []string
+	assigneesExcluded []string
 }
 
 func newConfiguration() (*configuration, error) {
@@ -47,6 +48,7 @@ func newConfiguration() (*configuration, error) {
 	repoOwner := repoParts[0]
 	repoName := repoParts[1]
 	assignees := strings.Split(os.Getenv(envVarAssignees), ",")
+	assigneesExcluded := strings.Split(os.Getenv(envVarAssigneesExcluded), ",")
 
 	return &configuration{
 		repoOwner:      repoOwner,
@@ -58,5 +60,6 @@ func newConfiguration() (*configuration, error) {
 		defaultLabel:   defaultLabel,
 		onlyMilestone:  os.Getenv(envVarOnlyMilestone) == "true",
 		assignees:      assignees,
+		assigneesExcluded: assigneesExcluded,
 	}, nil
 }

--- a/constants.go
+++ b/constants.go
@@ -8,4 +8,5 @@ const (
 	envVarAddLabel       string = "INPUT_ADDLABEL"
 	envVarDefaultLabel   string = "INPUT_DEFAULTLABEL"
 	envVarOnlyMilestone  string = "INPUT_ONLYMILESTONE"
+	envVarAssignees      string = "INPUT_ASSIGNEES"
 )

--- a/constants.go
+++ b/constants.go
@@ -1,13 +1,13 @@
 package main
 
 const (
-	envVarRepoFullName   string = "GITHUB_REPOSITORY"
-	envVarToken          string = "INPUT_SECRET"
-	envVarLabelPrefix    string = "INPUT_PREFIX"
-	envVarLabelSeparator string = "INPUT_LABELSEPARATOR"
-	envVarAddLabel       string = "INPUT_ADDLABEL"
-	envVarDefaultLabel   string = "INPUT_DEFAULTLABEL"
-	envVarOnlyMilestone  string = "INPUT_ONLYMILESTONE"
-	envVarAssignees      string = "INPUT_ASSIGNEES"
+	envVarRepoFullName      string = "GITHUB_REPOSITORY"
+	envVarToken             string = "INPUT_SECRET"
+	envVarLabelPrefix       string = "INPUT_PREFIX"
+	envVarLabelSeparator    string = "INPUT_LABELSEPARATOR"
+	envVarAddLabel          string = "INPUT_ADDLABEL"
+	envVarDefaultLabel      string = "INPUT_DEFAULTLABEL"
+	envVarOnlyMilestone     string = "INPUT_ONLYMILESTONE"
+	envVarAssignees         string = "INPUT_ASSIGNEES"
 	envVarAssigneesExcluded string = "INPUT_ASSIGNEESEXCLUDED"
 )

--- a/constants.go
+++ b/constants.go
@@ -9,4 +9,5 @@ const (
 	envVarDefaultLabel   string = "INPUT_DEFAULTLABEL"
 	envVarOnlyMilestone  string = "INPUT_ONLYMILESTONE"
 	envVarAssignees      string = "INPUT_ASSIGNEES"
+	envVarAssigneesExcluded string = "INPUT_ASSIGNEESEXCLUDED"
 )

--- a/issues.go
+++ b/issues.go
@@ -46,6 +46,25 @@ func issuesToModify(issues []*github.Issue, config *configuration) []*github.Iss
 			}
 		}
 
+		// Exclude issues with unwanted assignees
+		if len(config.assigneesExcluded) > 0 {
+			excluded := false
+			for _, assignee := range issue.Assignees {
+				for _, excludedAssignee := range config.assigneesExcluded {
+					if assignee.GetLogin() == excludedAssignee {
+						excluded = true
+						break
+					}
+				}
+				if excluded {
+					break
+				}
+			}
+			if excluded {
+				continue
+			}
+		}
+
 		if config.onlyMilestone && issue.GetMilestone() == nil {
 			continue
 		}

--- a/issues.go
+++ b/issues.go
@@ -27,6 +27,25 @@ func issuesToModify(issues []*github.Issue, config *configuration) []*github.Iss
 			continue
 		}
 
+		// Check if the issue has the required assignees
+		if len(config.assignees) > 0 {
+			assigned := false
+			for _, assignee := range issue.Assignees {
+				for _, validAssignee := range config.assignees {
+					if assignee.GetLogin() == validAssignee {
+						assigned = true
+						break
+					}
+				}
+				if assigned {
+					break
+				}
+			}
+			if !assigned {
+				continue
+			}
+		}
+
 		if config.onlyMilestone && issue.GetMilestone() == nil {
 			continue
 		}

--- a/issues_test.go
+++ b/issues_test.go
@@ -46,6 +46,7 @@ func TestIssuesToModify(t *testing.T) {
 	issue1Title := "issue1"
 	issue2Title := "issue2"
 	issue3Title := "issue3"
+	issue4Title := "issue4"
 	labelPrefix := "prefix"
 	separator := "/"
 	labelNameMatching := fmt.Sprintf("%s%s%s", labelPrefix, separator, "suffix")
@@ -215,6 +216,123 @@ func TestIssuesToModify(t *testing.T) {
 				},
 				{
 					Title: &issue2Title,
+				},
+			},
+		},
+		{
+			name: "unwanted_assignees_specified",
+			config: &configuration{
+				onlyMilestone:     false,
+				labelPrefix:       labelPrefix,
+				labelSeparator:    separator,
+				assigneesExcluded: []string{user1},
+			},
+			input: []*github.Issue{
+				{
+					Title: &issue1Title,
+					Assignees: []*github.User{
+						{Login: &user1},
+					},
+				},
+				{
+					Title: &issue2Title,
+					Assignees: []*github.User{
+						{Login: &user1},
+						{Login: &user2},
+					},
+				},
+				{
+					Title: &issue3Title,
+					Assignees: []*github.User{
+						{Login: &user2},
+						{Login: &user3},
+					},
+				},
+				{
+					Title:     &issue4Title,
+					Assignees: []*github.User{},
+				},
+			},
+			expected: []*github.Issue{
+				{
+					Title: &issue3Title,
+				},
+				{
+					Title: &issue4Title,
+				},
+			},
+		},
+		{
+			name: "unwanted_assignees_not_specified",
+			config: &configuration{
+				onlyMilestone:  false,
+				labelPrefix:    labelPrefix,
+				labelSeparator: separator,
+			},
+			input: []*github.Issue{
+				{
+					Title: &issue1Title,
+					Assignees: []*github.User{
+						{Login: &user1},
+					},
+				},
+				{
+					Title: &issue2Title,
+					Assignees: []*github.User{
+						{Login: &user1},
+						{Login: &user2},
+					},
+				},
+				{
+					Title:     &issue3Title,
+					Assignees: []*github.User{},
+				},
+			},
+			expected: []*github.Issue{
+				{
+					Title: &issue1Title,
+				},
+				{
+					Title: &issue2Title,
+				},
+				{
+					Title: &issue3Title,
+				},
+			},
+		},
+		{
+			name: "intersection_of_wanted_and_unwanted_assignees",
+			config: &configuration{
+				onlyMilestone:     false,
+				labelPrefix:       labelPrefix,
+				labelSeparator:    separator,
+				assignees:         []string{user1},
+				assigneesExcluded: []string{user2},
+			},
+			input: []*github.Issue{
+				{
+					Title: &issue1Title,
+					Assignees: []*github.User{
+						{Login: &user1},
+					},
+				},
+				{
+					Title: &issue2Title,
+					Assignees: []*github.User{
+						{Login: &user1},
+						{Login: &user2},
+					},
+				},
+				{
+					Title: &issue3Title,
+					Assignees: []*github.User{
+						{Login: &user2},
+					},
+				},
+			},
+			expected: []*github.Issue{
+				{
+					Title: &issue1Title,
 				},
 			},
 		},

--- a/issues_test.go
+++ b/issues_test.go
@@ -45,9 +45,13 @@ func issuesAreEqual(source, destination []*github.Issue) error {
 func TestIssuesToModify(t *testing.T) {
 	issue1Title := "issue1"
 	issue2Title := "issue2"
+	issue3Title := "issue3"
 	labelPrefix := "prefix"
 	separator := "/"
 	labelNameMatching := fmt.Sprintf("%s%s%s", labelPrefix, separator, "suffix")
+	user1 := "user1"
+	user2 := "user2"
+	user3 := "user3"
 
 	testCases := []struct {
 		name     string
@@ -125,6 +129,120 @@ func TestIssuesToModify(t *testing.T) {
 				},
 				{
 					Title: &issue2Title,
+				},
+			},
+			expected: []*github.Issue{
+				{
+					Title: &issue2Title,
+				},
+			},
+		},
+		{
+			name: "issue_with_specified_assignees",
+			config: &configuration{
+				onlyMilestone:  false,
+				labelPrefix:    labelPrefix,
+				labelSeparator: separator,
+				assignees:      []string{user1, user2, user3},
+			},
+			input: []*github.Issue{
+				{
+					Title: &issue1Title,
+					Assignees: []*github.User{
+						{Login: &user1},
+					},
+				},
+				{
+					Title: &issue2Title,
+				},
+				{
+					Title: &issue3Title,
+					Assignees: []*github.User{
+						{Login: &user1},
+						{Login: &user2},
+						{Login: &user3},
+					},
+				},
+			},
+			expected: []*github.Issue{
+				{
+					Title: &issue1Title,
+				},
+				{
+					Title: &issue3Title,
+				},
+			},
+		},
+		{
+			name: "no_assignee_matched",
+			config: &configuration{
+				onlyMilestone:  false,
+				labelPrefix:    labelPrefix,
+				labelSeparator: separator,
+				assignees:      []string{user1, user2, user3},
+			},
+			input: []*github.Issue{
+				{
+					Title: &issue1Title,
+					Assignees: []*github.User{
+						{Login: github.String("user4")},
+					},
+				},
+			},
+			expected: []*github.Issue{},
+		},
+		{
+			name: "assignees_not_specified",
+			config: &configuration{
+				onlyMilestone:  false,
+				labelPrefix:    labelPrefix,
+				labelSeparator: separator,
+			},
+			input: []*github.Issue{
+				{
+					Title: &issue1Title,
+				},
+				{
+					Title: &issue2Title,
+					Assignees: []*github.User{
+						{Login: &user2},
+					},
+				},
+			},
+			expected: []*github.Issue{
+				{
+					Title: &issue1Title,
+				},
+				{
+					Title: &issue2Title,
+				},
+			},
+		},
+		{
+			name: "assignees_with_label",
+			config: &configuration{
+				onlyMilestone:  false,
+				labelPrefix:    labelPrefix,
+				labelSeparator: separator,
+				assignees:      []string{user1, user2, user3},
+			},
+			input: []*github.Issue{
+				{
+					Title: &issue1Title,
+					Assignees: []*github.User{
+						{Login: &user1},
+					},
+					Labels: []github.Label{
+						{
+							Name: &labelNameMatching,
+						},
+					},
+				},
+				{
+					Title: &issue2Title,
+					Assignees: []*github.User{
+						{Login: &user2},
+					},
 				},
 			},
 			expected: []*github.Issue{

--- a/issues_test.go
+++ b/issues_test.go
@@ -337,6 +337,42 @@ func TestIssuesToModify(t *testing.T) {
 			},
 		},
 		{
+			name: "wanted_and_unwanted_has_duplicated_assignees",
+			config: &configuration{
+				onlyMilestone:     false,
+				labelPrefix:       labelPrefix,
+				labelSeparator:    separator,
+				assignees:         []string{user1, user2, user3},
+				assigneesExcluded: []string{user2},
+			},
+			input: []*github.Issue{
+				{
+					Title: &issue1Title,
+					Assignees: []*github.User{
+						{Login: &user1},
+					},
+				},
+				{
+					Title: &issue2Title,
+					Assignees: []*github.User{
+						{Login: &user2},
+					},
+				},
+				{
+					Title: &issue3Title,
+					Assignees: []*github.User{
+						{Login: &user1},
+						{Login: &user2},
+					},
+				},
+			},
+			expected: []*github.Issue{
+				{
+					Title: &issue1Title,
+				},
+			},
+		},
+		{
 			name: "assignees_with_label",
 			config: &configuration{
 				onlyMilestone:  false,


### PR DESCRIPTION
This feature allows users to filter target issues to process by using their assignees as filter criteria (closes #4)

new arguments:
- `assignees`: only issues with assignees in this array will be processed
- `assigneesExcluded`: only issues that do not have assignees in this array will be processed

spec summary:
- All issues will be processed if `assignees` and `assigneesExcluded` are not specified
- `assigneesExcluded` overrides `assignees` (tested [here](https://github.com/Rindrics/require-label-prefix/blob/8276b32dd45886234abaacda2c9140959e8b3db8/issues_test.go#L339-L374))